### PR TITLE
Temporary fixes weird Android libraries

### DIFF
--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -68,8 +68,9 @@ static SectionInfo getSectionInfo(const char *imageName,
   SectionInfo sectionInfo = { 0, nullptr };
   void *handle = dlopen(imageName, RTLD_LAZY | RTLD_NOLOAD);
   if (!handle) {
-    fatalError(/* flags = */ 0, "dlopen() failed on `%s': %s", imageName,
-               dlerror());
+    //fatalError(/* flags = */ 0, "dlopen() failed on `%s': %s", imageName,
+    //           dlerror());
+    return sectionInfo;
   }
   void *symbol = dlsym(handle, sectionName);
   if (symbol) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
On Android, Swift Runtime is trying to load weird and/or private libraries, so we should disable this fatalError.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
